### PR TITLE
Refactoring client v2

### DIFF
--- a/lib/webhdfs/client_v2.rb
+++ b/lib/webhdfs/client_v2.rb
@@ -69,6 +69,16 @@ module WebHDFS
       }
     end
 
+    def checkCon(httpVerb,optTable,path,options,body = nil):
+        WebHDFS.check_options(options, OPT_TABLE[optTable])
+        # delete or mkdir
+        if body.nil?
+          return operate_requests(httpVerb, path, optTable, options)
+        else
+          return operate_requests(httpVerb, path, optTable, options,body)
+        end
+    end
+
     # curl -i -X PUT "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=CREATE
     #                 [&overwrite=<true|false>][&blocksize=<LONG>]
     #                 [&replication=<SHORT>]
@@ -84,16 +94,14 @@ module WebHDFS
     #                      APPEND[&buffersize=<INT>]"
     def append(path, body, options = {})
       options = options.merge('data' => 'true') if @httpfs_mode
-      WebHDFS.check_options(options, OPT_TABLE['APPEND'])
-      res = operate_requests('POST', path, 'APPEND', options, body)
+      res = checkCon('POST','APPEND',path,options,body)
       res.code == '200'
     end
 
     # curl -i -L "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=OPEN
     #                [&offset=<LONG>][&length=<LONG>][&buffersize=<INT>]"
     def read(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['OPEN'])
-      res = operate_requests('GET', path, 'OPEN', options)
+      res = checkCon('GET','OPEN',path,options)
       res.body
     end
 
@@ -102,8 +110,7 @@ module WebHDFS
     # curl -i -X PUT "http://<HOST>:<PORT>/<PATH>?op=
     #                     MKDIRS[&permission=<OCTAL>]"
     def mkdir(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['MKDIRS'])
-      res = operate_requests('PUT', path, 'MKDIRS', options)
+      res = checkCon('PUT','MKDIRS',path,options)
       WebHDFS.check_success_json(res, 'boolean')
     end
 
@@ -122,31 +129,27 @@ module WebHDFS
     # curl -i -X DELETE "http://<host>:<port>/webhdfs/v1/<path>?op=DELETE
     #                          [&recursive=<true|false>]"
     def delete(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['DELETE'])
-      res = operate_requests('DELETE', path, 'DELETE', options)
+      res = checkCon('DELETE','DELETE',path,options)
       WebHDFS.check_success_json(res, 'boolean')
     end
 
     # curl -i  "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=GETFILESTATUS"
     def stat(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['GETFILESTATUS'])
-      res = operate_requests('GET', path, 'GETFILESTATUS', options)
+      res = checkCon('GET','GETFILESTATUS',path,options)
       WebHDFS.check_success_json(res, 'FileStatus')
     end
     alias getfilestatus stat
 
     # curl -i  "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=LISTSTATUS"
     def list(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['LISTSTATUS'])
-      res = operate_requests('GET', path, 'LISTSTATUS', options)
+      res = checkCon('GET','LISTSTATUS',path,options)
       WebHDFS.check_success_json(res, 'FileStatuses')['FileStatus']
     end
     alias liststatus list
 
     # curl -i "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=GETCONTENTSUMMARY"
     def content_summary(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['GETCONTENTSUMMARY'])
-      res = operate_requests('GET', path, 'GETCONTENTSUMMARY', options)
+      res = checkCon('GET','GETCONTENTSUMMARY',path,options)
       WebHDFS.check_success_json(res, 'ContentSummary')
     end
     alias getcontentsummary content_summary

--- a/lib/webhdfs/client_v2.rb
+++ b/lib/webhdfs/client_v2.rb
@@ -79,6 +79,20 @@ module WebHDFS
         end
     end
 
+    def checkPrivliage(optTable,optionsHash)
+      WebHDFS.check_options(options, OPT_TABLE[optTable])
+      unless options.key?(optionsHash[0]) || options.key?(optionsHash[1]) ||
+                 options.key?(optionsHash[0]) || options.key?(optionsHash[1])
+
+        if optionsHash[0] == 'modificationtime' or optionsHash[0] == 'modificationtime'
+            raise ArgumentError, "'chown' needs at least one of " \
+                               'modificationtime or accesstime'
+        elsif optionsHash[0] == 'owner' or optionsHash[0] == 'group'
+          raise ArgumentError, "'chown' needs at least one of owner or group"
+        end
+
+      end
+    end
     # curl -i -X PUT "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=CREATE
     #                 [&overwrite=<true|false>][&blocksize=<LONG>]
     #                 [&replication=<SHORT>]
@@ -183,11 +197,7 @@ module WebHDFS
     # curl -i -X PUT "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=SETOWNER
     #                          [&owner=<USER>][&group=<GROUP>]"
     def chown(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['SETOWNER'])
-      unless options.key?('owner') || options.key?('group') ||
-             options.key?(:owner) || options.key?(:group)
-        raise ArgumentError, "'chown' needs at least one of owner or group"
-      end
+      checkPrivliage('SETOWNER',['owner','group'])
       res = operate_requests('PUT', path, 'SETOWNER', options)
       res.code == '200'
     end
@@ -209,12 +219,7 @@ module WebHDFS
     # motidicationtime: radix-10 logn integer
     # accesstime: radix-10 logn integer
     def touch(path, options = {})
-      WebHDFS.check_options(options, OPT_TABLE['SETTIMES'])
-      unless options.key?('modificationtime') || options.key?('accesstime') ||
-             options.key?(:modificationtime) || options.key?(:accesstime)
-        raise ArgumentError, "'chown' needs at least one of " \
-                               'modificationtime or accesstime'
-      end
+      checkPrivliage('SETTIMES',['modificationtime','accesstime'])
       res = operate_requests('PUT', path, 'SETTIMES', options)
       res.code == '200'
     end


### PR DESCRIPTION
The way I'm doing `Raise error method` might fail, if so then this way might be suggested to be done:

```ruby

    def checkPrivliage(optTable,optionsHash)
      WebHDFS.check_options(options, OPT_TABLE[optTable])
      unless options.key?(optionsHash[0]) || options.key?(optionsHash[1]) ||
                 options.key?(optionsHash[0]) || options.key?(optionsHash[1])

        if optionsHash[0] == 'modificationtime' or optionsHash[0] == 'modificationtime'
            raise ArgumentError, "'chown' needs at least one of " \
                               'modificationtime or accesstime'
        elsif optionsHash[0] == 'owner' or optionsHash[0] == 'group'
          raise ArgumentError, "'chown' needs at least one of owner or group"
        end

      end
    end

    def chown(path, options = {})
        if checkPrivliage('SETOWNER',['owner','group'])
           res = operate_requests('PUT', path, 'SETOWNER', options)
           res.code == '200'
        else
          raise ArgumentError, "error here
       end
    end

```